### PR TITLE
added default value for templates

### DIFF
--- a/src/main/java/com/automationanywhere/botcommand/KlippaOCRAPI/commands/ParseDocument.java
+++ b/src/main/java/com/automationanywhere/botcommand/KlippaOCRAPI/commands/ParseDocument.java
@@ -47,7 +47,7 @@ public class ParseDocument {
             @Idx(index = "2", type = AttributeType.CREDENTIAL) @Pkg(label = "[[ParseDocument.APIKey.label]]", description = "[[ParseDocument.APIKey.label]]") @NotEmpty SecureString APIKey,
             @Idx(index = "3", type = AttributeType.TEXT) @Pkg(label = "[[ParseDocument.DocumentURL.label]]", description = "[[ParseDocument.DocumentURL.label]]") String DocumentURL,
             @Idx(index = "4", type = AttributeType.FILE) @Pkg(label = "[[ParseDocument.DocumentPath.label]]", description = "[[ParseDocument.DocumentPath.label]]") String DocumentPath,
-            @Idx(index = "5", type = AttributeType.TEXT) @Pkg(label = "[[ParseDocument.Template.label]]", description = "[[ParseDocument.Template.label]]") String Template,
+            @Idx(index = "5", type = AttributeType.TEXT) @Pkg(label = "[[ParseDocument.Template.label]]", description = "[[ParseDocument.Template.label]]", default_value_type = STRING, default_value = "financial_full") String Template,
             @Idx(index = "6", type = AttributeType.SELECT, options = {
                     @Idx.Option(index = "6.1", pkg = @Pkg(label = "[[ParseDocument.PDFTextExtraction.fast.label]]", value = "fast")),
                     @Idx.Option(index = "6.2", pkg = @Pkg(label = "[[ParseDocument.PDFTextExtraction.full.label]]", value = "full")),


### PR DESCRIPTION
For new users of this repo it will now use a default value for the template's variable.
This is to, by default, use the newest financial_full parser instead of an older parser when not setting a template.